### PR TITLE
Use jq to compare two json in CI

### DIFF
--- a/lab7/validate.sh
+++ b/lab7/validate.sh
@@ -20,7 +20,9 @@ ans=$(cat <<-END
 END
 )
 curl -o result.txt `cat app_url.txt`bookshelf
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -37,7 +39,9 @@ ans=$(cat <<-END
 END
 )
 curl -o result.txt `cat app_url.txt`bookshelf/1
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -52,7 +56,9 @@ ans=$(cat <<-END
 END
 )
 curl -o result.txt `cat app_url.txt`bookshelf/2
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -69,7 +75,9 @@ ans=$(cat <<-END
 END
 )
 curl -X POST -H 'Content-Type: application/json' -d '{"ID":"2","NAME":"Pride and Prejudice","PAGES":"600"}' -o result.txt `cat app_url.txt`bookshelf
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -86,7 +94,9 @@ ans=$(cat <<-END
 END
 )
 curl -o result.txt `cat app_url.txt`bookshelf/2
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -103,7 +113,9 @@ ans=$(cat <<-END
 END
 )
 curl -X POST -H 'Content-Type: application/json' -d '{"ID":"3","NAME":"原子習慣：細微改變帶來巨大成就的實證法則","PAGES":"33"}' -o result.txt `cat app_url.txt`bookshelf
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -118,7 +130,9 @@ ans=$(cat <<-END
 END
 )
 curl -X POST -H 'Content-Type: application/json' -d '{"ID":"3","NAME":"原子習慣：細微改變帶來巨大成就的實證法則","PAGES":"33"}' -o result.txt `cat app_url.txt`bookshelf
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -135,7 +149,9 @@ ans=$(cat <<-END
 END
 )
 curl -X PUT -H 'Content-Type: application/json' -d '{"ID":"3","NAME":"原子習慣：細微改變帶來巨大成就的實證法則","PAGES":"600"}' -o result.txt `cat app_url.txt`bookshelf/2
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -152,7 +168,9 @@ ans=$(cat <<-END
 END
 )
 curl -X DELETE  -o result.txt `cat app_url.txt`bookshelf/3
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"
@@ -169,7 +187,9 @@ ans=$(cat <<-END
 END
 )
 curl -X DELETE  -o result.txt `cat app_url.txt`bookshelf/3
-if [ "$(echo $ans)" != "$(cat result.txt)" ] ; then
+echo $ans > ans.txt
+DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
+if [ "$DIFF" != "" ] ; then
   echo "right ans="$ans
   echo "your ans=$(cat result.txt)"
   echo "wrong answer ; NO POINT"

--- a/lab7/validate.sh
+++ b/lab7/validate.sh
@@ -149,7 +149,7 @@ ans=$(cat <<-END
 END
 )
 
-curl -X PUT -H 'Content-Type: application/json' -d '{"ID":"3","NAME":"原子習慣：細微改變帶來巨大成就的實證法則","PAGES":"600"}' -o result.txt `cat app_url.txt`bookshelf/2
+curl -X PUT -H 'Content-Type: application/json' -d '{"ID":"3","NAME":"原子習慣：細微改變帶來巨大成就的實證法則","PAGES":"600"}' -o result.txt `cat app_url.txt`bookshelf/3
 echo $ans > ans.txt
 DIFF=$(diff <(jq -S . result.txt) <(jq -S . ans.txt))
 if [ "$DIFF" != "" ] ; then


### PR DESCRIPTION
Previous `validate.sh` use below code to compare the ans with result.
```sh
if [ "$(echo $ans)" != "$(cat result.txt)" ]
```
However, `"$(echo $ans)"` is a one-line text without indents looks like
```json
[ { "id": "1", "name": "Blue Bird", "pages": "500" } ]
```
which won't match the `indentedJSON` format that the spec required.
```json
[
    {
        "id": "1",
        "name": "Blue Bird",
        "pages": "500"
    }
]%
```
Using `jq` to compare two JSON files might be a better choice.

